### PR TITLE
PayGo + Four button UI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,13 @@ FILES = \
 	cache.py \
 	lcddriver.py \
 	track.py \
-	pages.py
+	pages.py \
+	four_button_pages.py \
+	four_button_ui.py \
+	simple_ui.py \
+	payg_service.py
+
+compile: ;
 
 help:
 	@echo "The following make targets are available"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # dbus-characterdisplay
+
+This service is used to handle the display of menus and alerts on the character display LCD (1602) as well as handle user interaction when available. 
+
+The following behaviours are expected: 
+- On devices with 0 buttons: the menus automatically roll
+- On devices with 1 buttons: the menus roll, and pressing the button force the rolling
+- On devices with 4 buttons: the user can see the available menu list and select the menu to see

--- a/dbus_characterdisplay.py
+++ b/dbus_characterdisplay.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
-import time
-import signal
 import sys
 import logging
 from os.path import basename, dirname, abspath
 from os.path import join as pathjoin
 from argparse import ArgumentParser
-from functools import partial
-from itertools import izip
+import subprocess
 import gettext
 import dbus
 from dbus.mainloop.glib import DBusGMainLoop
@@ -19,10 +16,11 @@ from cache import smart_dict
 from pages import StatusPage, ReasonPage, BatteryPage, SolarPage, SolarHistoryPage
 from pages import AcPage, AcPhasePage, AcOutPhasePage
 from pages import LanPage, WlanPage, VebusErrorPage, SolarErrorPage, VebusAlarmsPage
+from four_button_ui import FourButtonUserInterface
+from simple_ui import SimpleUserInterface
 
-VERSION = 0.4
-ROLL_TIMEOUT = 5
-BACKLIGHT_TIMEOUT = 300
+VERSION = 0.5
+FOUR_BUTTON_DEVICES = ['victronenergy,paygo']
 
 # Set up i18n
 gettext.install("messages",
@@ -37,35 +35,6 @@ _screens = [StatusPage(), ReasonPage(), VebusErrorPage(),
 	SolarHistoryPage(0), SolarHistoryPage(1),
 	LanPage(), WlanPage()]
 
-class cycle(object):
-	""" Cyclical list-iterator that can be reset. """
-	def __init__(self, li):
-		self.li = li
-		self.reset()
-	def reset(self):
-		self.iterable = iter(self.li)
-	def next(self):
-		try:
-			return next(self.iterable)
-		except StopIteration:
-			self.reset()
-			return next(self.iterable)
-	def __iter__(self):
-		return self
-
-screens = cycle(_screens)
-
-def show_screen(conn, screen, lcd):
-	return screen.display(conn, lcd)
-
-def roll_screens(conn, lcd, auto):
-	# Cheap way of avoiding infinite loop
-	for screen, _ in izip(screens, _screens):
-		if auto and not screen.auto:
-			continue
-		if show_screen(conn, screen, lcd):
-			return screen
-	return None
 
 def main():
 	parser = ArgumentParser(description=sys.argv[0])
@@ -122,44 +91,27 @@ def main():
 	except OSError:
 		kbd = None
 
-	# Context object for event handlers
-	ctx = smart_dict({'count': ROLL_TIMEOUT, 'kbd': kbd, 'screen': None})
+	has_four_buttons = subprocess.check_output(["/usr/bin/board-compat"]).strip() in FOUR_BUTTON_DEVICES
+
+	if has_four_buttons:
+		ui_handler = FourButtonUserInterface(lcd, conn, kbd, _screens)
+	else:
+		ui_handler = SimpleUserInterface(lcd, conn, kbd, _screens)
+
+	ui_handler.start()
 
 	if kbd is not None:
-		def keypress(fd, condition, ctx):
-			for event in ctx.kbd.read():
-				# We could check for event.code == ecodes.KEY_LEFT but there
-				# is only one button, so lets just make them all do the same.
-				if event.type == ecodes.EV_KEY and event.value == 1:
-					# If backlight is off, turn it on
-					if lcd.on:
-						# When buttons are used, stay on selected screen longer
-						ctx.count = ROLL_TIMEOUT * 6
-					else:
-						# Except when the backlight was off, then normal timeout.
-						ctx.count = ROLL_TIMEOUT
-						lcd.on = True
-						screens.reset()
-
-					ctx.screen = roll_screens(conn, lcd, False)
-
+		def keypress(fd, condition):
+			ui_handler.key_pressed()
 			return True
 
-		gobject.io_add_watch(kbd.fd, gobject.IO_IN, keypress, ctx)
+		gobject.io_add_watch(kbd.fd, gobject.IO_IN, keypress)
 
-	def tick(ctx):
-		if ctx.count == 0:
-			ctx.screen = roll_screens(conn, lcd, True)
-			if lcd.on_time > BACKLIGHT_TIMEOUT:
-				lcd.on = False
-		elif ctx.screen is not None:
-			# Update the screen text
-			ctx.screen.display(conn, lcd)
-
-		ctx.count = ctx.count - 1 if ctx.count > 0 else ROLL_TIMEOUT
+	def tick():
+		ui_handler.tick()
 		return True
 
-	gobject.timeout_add(1000, tick, ctx)
+	gobject.timeout_add(1000, tick)
 
 	gobject.MainLoop().run()
 

--- a/four_button_pages.py
+++ b/four_button_pages.py
@@ -1,0 +1,136 @@
+from evdev import ecodes
+from payg_service import PAYGService
+
+
+class StaticMenu:
+
+    def __init__(self, static_page):
+        self._static_page = static_page
+
+    def is_available(self, conn):
+        if self._static_page.get_text(conn) is None:
+            return False
+        return True
+
+    def enter(self, conn, display):
+        self._static_page.display(conn, display)
+
+    def update(self, conn, display, key_pressed):
+        if key_pressed:
+            return False
+        return True
+
+
+class TokenEntryMenu:
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.payg_service = PAYGService(self.conn)
+
+    def is_available(self, conn):
+        return self.payg_service.service_available()
+
+    def enter(self, conn, display):
+        self.was_locked = False
+        self.token_typed = ''
+        self.current_digit = 5
+        self.token_entry_complete = False
+        self.to_display = self.token_typed + str(self.current_digit)
+
+        display.clear()
+
+        if not self.payg_service.token_entry_allowed():
+            display.display_string('Token entry lock'.center(16), 1)
+            minutes = self.payg_service.get_minutes_of_token_block()
+            date_string = 'for {minutes} min.'.format(minutes=minutes)
+            display.display_string(date_string.center(16), 2)
+        else:
+            display.display_string('Enter Token', 1)
+            display.display_string(self.to_display.ljust(9, '_'), 2)
+
+    def update(self, conn, display, key_pressed):
+        if self.token_entry_complete:
+            if key_pressed:
+                return False
+            return True
+        if not self.payg_service.token_entry_allowed():
+            display.display_string('Token entry lock'.center(16), 1)
+            minutes = self.payg_service.get_minutes_of_token_block()
+            date_string = 'for {minutes} min.'.format(minutes=minutes)
+            display.display_string(date_string.center(16), 2)
+            self.was_locked = True
+            if key_pressed == ecodes.KEY_LEFT:
+                return False
+        else:
+            if key_pressed == ecodes.KEY_RIGHT:
+                self.token_typed = self.token_typed + str(self.current_digit)
+                if len(self.token_typed) == 9:
+                    self.complete_token_entry(display, self.token_typed)
+                    return True
+                self.current_digit = 5
+            if key_pressed == ecodes.KEY_LEFT:
+                if len(self.token_typed) == 0:
+                    return False
+                else:
+                    self.current_digit = int(self.token_typed[-1:]) if self.token_typed[-1:] else 5
+                    self.token_typed = self.token_typed[:-1]
+            if key_pressed == ecodes.KEY_UP:
+                self.current_digit += 1
+                if self.current_digit > 9:
+                    self.current_digit = 0
+            if key_pressed == ecodes.KEY_DOWN:
+                self.current_digit -= 1
+                if self.current_digit < 0:
+                    self.current_digit = 9
+            if key_pressed or self.was_locked:
+                if self.was_locked:
+                    display.clear()
+                    self.was_locked = False
+                self.to_display = self.token_typed + str(self.current_digit)
+                display.display_string('Enter Token', 1)
+                display.display_string(self.to_display.ljust(9, '_'), 2)
+        return True
+
+    def complete_token_entry(self, display, token_typed):
+        self.token_entry_complete = True
+        is_token_valid = self.payg_service.update_device_status_if_code_valid(int(token_typed))
+        display.clear()
+        if is_token_valid:
+            display.display_string('Token Valid'.center(16), 1)
+            if not self.payg_service.is_payg_enabled():
+                display.display_string('Active Forever'.center(16), 2)
+            else:
+                days_left, hours_left = self.payg_service.get_number_of_days_and_hours_left()
+                date_string = '{days} days, {hours} h'.format(days=days_left, hours=hours_left)
+                display.display_string(date_string.center(16), 2)
+        else:
+            display.display_string('Token Invalid'.center(16), 1)
+            display.display_string(''.center(16), 2)
+                
+                
+class PAYGStatusMenu:
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.payg_service = PAYGService(self.conn)
+        
+    def is_available(self, conn):
+        return self.payg_service.service_available()
+
+    def enter(self, conn, display):
+        if not self.payg_service.is_payg_enabled():
+            display.display_string('Active'.center(16), 1)
+            display.display_string('Forever'.center(16), 2)
+        elif self.payg_service.is_active():
+            display.display_string('Active For'.center(16), 1)
+            days_left, hours_left = self.payg_service.get_number_of_days_and_hours_left()
+            date_string = '{days} days, {hours} h'.format(days=days_left, hours=hours_left)
+            display.display_string(date_string.center(16), 2)
+        else:
+            display.display_string('Not Active'.center(16), 1)
+            display.display_string('Please Activate'.center(16), 2)
+
+    def update(self, conn, display, key_pressed):
+        if key_pressed:
+            return False
+        return True

--- a/four_button_ui.py
+++ b/four_button_ui.py
@@ -1,0 +1,106 @@
+from evdev import ecodes
+from datetime import datetime, timedelta
+from four_button_pages import StaticMenu, TokenEntryMenu, PAYGStatusMenu
+
+
+class FourButtonUserInterface:
+
+    BACKLIGHT_TIMEOUT = 300
+    
+    def __init__(self, lcd, conn, kbd, static_pages):
+        self.conn = conn
+        self.disp = lcd
+        self.kbd = kbd
+        self.static_pages = static_pages
+        self.last_key_pressed = datetime.now()
+        self.selected_menu = None
+        self.current_menu = None
+        self.index = 0
+        self.last_index = 1
+        self.menus = [
+            ('PAYG Status', PAYGStatusMenu(self.conn)),
+            ('Enter Token', TokenEntryMenu(self.conn)),
+            ('LAN Status', StaticMenu(self.static_pages[16])),
+            ('WiFi Status', StaticMenu(self.static_pages[17])),
+            ('General Status', StaticMenu(self.static_pages[0])),
+            ('Solar Status', StaticMenu(self.static_pages[12])),
+            ('Battery Status', StaticMenu(self.static_pages[11])),
+            ('Solar History', StaticMenu(self.static_pages[14])),
+        ]
+        self.alarm_menus = [
+            StaticMenu(self.static_pages[2]), # VE Bus error
+            StaticMenu(self.static_pages[3]),  # VE Bus alarm
+            StaticMenu(self.static_pages[13]),  # Solar error
+        ]
+
+    def start(self):
+        self.disp.clear()
+        self.update_menu_list()
+
+    def key_pressed(self):
+        self.last_key_pressed = datetime.now()
+        for event in self.kbd.read():
+            if event.type == ecodes.EV_KEY and event.value == 1:
+                self.update_current_menu(event.code)
+
+    def tick(self):
+        self.display_alarms()
+        self.update_current_menu(None)
+        self.update_backlight_status()
+
+    def update_backlight_status(self):
+        if self.last_key_pressed + timedelta(seconds=self.BACKLIGHT_TIMEOUT) < datetime.now():
+            self.disp.on = False
+        else:
+            self.disp.on = True
+
+    def display_alarms(self):
+        for alarm in self.alarm_menus:
+            alarm.enter(self.conn, self.disp) # It will only display if the menu actually exists
+
+    def get_available_menus(self):
+        menus = []
+        for menu in self.menus:
+            if menu[1].is_available(self.conn):
+                menus.append(menu)
+        return menus
+
+    def update_menu_list(self):
+        menus = self.get_available_menus()
+
+        if self.index < self.last_index:
+            top_string = menus[self.index][0].ljust(15, ' ') + '>'
+            bottom_string = menus[self.index + 1][0].ljust(15, ' ') + ' '
+        else:
+            top_string = menus[self.index - 1][0].ljust(15, ' ') + ' '
+            bottom_string = menus[self.index][0].ljust(15, ' ') + '>'
+
+        self.disp.display_string(top_string, 1)
+        self.disp.display_string(bottom_string, 2)
+
+        self.selected_menu = menus[self.index][1]
+    
+    def menu_list_loop(self, key_pressed):
+        number_of_menus = len(self.get_available_menus())
+        if key_pressed == ecodes.KEY_UP:
+            if self.index > 0:
+                self.last_index = self.index
+                self.index -= 1
+                self.update_menu_list()
+        if key_pressed == ecodes.KEY_DOWN:
+            if self.index < number_of_menus - 1:
+                self.last_index = self.index
+                self.index += 1
+                self.update_menu_list()
+        if key_pressed == ecodes.KEY_RIGHT:
+            self.current_menu = self.selected_menu
+            self.current_menu.enter(self.conn, self.disp)
+
+    def update_current_menu(self, key_pressed):
+        if self.current_menu is not None and not self.current_menu.update(self.conn, self.disp, key_pressed):
+            self.current_menu = None
+            key_pressed = None
+            self.disp.clear()
+            self.update_menu_list()
+        if self.current_menu is None:
+            self.menu_list_loop(key_pressed)

--- a/four_button_ui.py
+++ b/four_button_ui.py
@@ -17,6 +17,7 @@ class FourButtonUserInterface:
         self.current_menu = None
         self.index = 0
         self.last_index = 1
+        self.last_menu_number = 0
         self.menus = [
             ('PAYG Status', PAYGStatusMenu(self.conn)),
             ('Enter Token', TokenEntryMenu(self.conn)),
@@ -68,12 +69,24 @@ class FourButtonUserInterface:
     def update_menu_list(self):
         menus = self.get_available_menus()
 
-        if self.index < self.last_index:
-            top_string = menus[self.index][0].ljust(15, ' ') + '>'
-            bottom_string = menus[self.index + 1][0].ljust(15, ' ') + ' '
+        number_menus = len(menus)
+        if number_menus < self.last_menu_number:
+            self.index = 0
+        self.last_menu_number = number_menus
+
+        if number_menus == 0:
+            top_string = ' Victron Energy '
+            bottom_string = ' '.ljust(16, ' ')
+        elif number_menus == 1:
+            top_string = menus[0][0].ljust(15, ' ') + '>'
+            bottom_string = ' '.ljust(16, ' ')
         else:
-            top_string = menus[self.index - 1][0].ljust(15, ' ') + ' '
-            bottom_string = menus[self.index][0].ljust(15, ' ') + '>'
+            if self.index < self.last_index:
+                top_string = menus[self.index][0].ljust(15, ' ') + '>'
+                bottom_string = menus[self.index + 1][0].ljust(15, ' ') + ' '
+            else:
+                top_string = menus[self.index - 1][0].ljust(15, ' ') + ' '
+                bottom_string = menus[self.index][0].ljust(15, ' ') + '>'
 
         self.disp.display_string(top_string, 1)
         self.disp.display_string(bottom_string, 2)
@@ -95,6 +108,8 @@ class FourButtonUserInterface:
         if key_pressed == ecodes.KEY_RIGHT:
             self.current_menu = self.selected_menu
             self.current_menu.enter(self.conn, self.disp)
+        else:
+            self.update_menu_list()
 
     def update_current_menu(self, key_pressed):
         if self.current_menu is not None and not self.current_menu.update(self.conn, self.disp, key_pressed):

--- a/payg_service.py
+++ b/payg_service.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta
+from track import Tracker
+
+
+class PAYGService:
+    SERVICE_NAME = 'com.victronenergy.paygo'
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.tracker = Tracker()
+
+    def service_available(self):
+        payg_enabled = self.tracker.query(self.conn, self.SERVICE_NAME, "/Status/PaygoEnabled")
+        if payg_enabled is None:
+            return False
+        else:
+            return True
+
+    def is_active(self):
+        is_active = self.tracker.query(self.conn, self.SERVICE_NAME, "/Status/CurrentlyActive")
+        if is_active:
+            return True
+        else:
+            return False
+
+    def is_payg_enabled(self):
+        payg_enabled = self.tracker.query(self.conn, self.SERVICE_NAME, "/Status/PaygoEnabled")
+        if payg_enabled is not None:
+            return payg_enabled
+        else:
+            return True
+
+    def token_entry_allowed(self):
+        if not self._get_blocked_until_date():
+            return True
+        if datetime.now() >= self._get_blocked_until_date():
+            return True
+        else:
+            return False
+
+    def get_minutes_of_token_block(self):
+        if not self._get_blocked_until_date():
+            return 0
+        td = self._get_blocked_until_date() - datetime.now()
+        days_left = td.days
+        minutes_left = int(round(float(td.seconds) / 60, 0))
+        return minutes_left+(days_left*60*24)
+
+    def get_number_of_days_and_hours_left(self):
+        if not self._get_expiration_date():
+            return 0, 0
+        td = self._get_expiration_date() - datetime.now()
+        days_left = td.days
+        hours_left = int(round(float(td.seconds)/3600, 0))
+        if hours_left == 24:
+            days_left += 1
+            hours_left = 0
+        return days_left, hours_left
+
+    def update_device_status_if_code_valid(self, token):
+        self._dbus_write(self.SERVICE_NAME, "/Tokens/Last", token)
+        token_valid = self.tracker.query(self.conn, self.SERVICE_NAME, "/Tokens/LastTokenValid")
+        if token_valid:
+            return True
+        else:
+            return False
+
+    def _get_expiration_date(self):
+        expiration_date = self.tracker.query(self.conn, self.SERVICE_NAME, "/Status/ActiveUntilDate")
+        if expiration_date is not None:
+            return self._datetime_from_unix_timestamp(expiration_date)
+        return None
+
+    def _get_blocked_until_date(self):
+        blocked_until_date = self.tracker.query(self.conn, self.SERVICE_NAME, "/Tokens/EntryBlockedUntilDate")
+        if blocked_until_date is not None:
+            return self._datetime_from_unix_timestamp(blocked_until_date)
+        return None
+
+    def _dbus_write(self, service_name, path, value):
+        return self.conn.call_blocking(service_name, path, None, "SetValue", 's', [str(value)])
+
+    def _datetime_from_unix_timestamp(self, timestamp):
+        return datetime(1970, 1, 1) + timedelta(seconds=timestamp)

--- a/simple_ui.py
+++ b/simple_ui.py
@@ -1,0 +1,77 @@
+from itertools import izip
+from evdev import ecodes
+
+
+class cycle(object):
+	""" Cyclical list-iterator that can be reset. """
+	def __init__(self, li):
+		self.li = li
+		self.reset()
+	def reset(self):
+		self.iterable = iter(self.li)
+	def next(self):
+		try:
+			return next(self.iterable)
+		except StopIteration:
+			self.reset()
+			return next(self.iterable)
+	def __iter__(self):
+		return self
+    
+
+class SimpleUserInterface:
+
+    ROLL_TIMEOUT = 5
+    BACKLIGHT_TIMEOUT = 300
+
+    def __init__(self, lcd, conn, kbd, static_screens):
+        self.lcd = lcd
+        self.conn = conn
+        self.kbd = kbd
+        self._screens = static_screens
+        self.screen_cycle = cycle(self._screens)
+        self.screen = None
+        self.count = self.ROLL_TIMEOUT
+
+    def start(self):
+        pass
+
+    def key_pressed(self):
+        for event in self.kbd.read():
+            # We could check for event.code == ecodes.KEY_LEFT but there
+            # is only one button, so lets just make them all do the same.
+            if event.type == ecodes.EV_KEY and event.value == 1:
+                # If backlight is off, turn it on
+                if self.lcd.on:
+                    # When buttons are used, stay on selected screen longer
+                    self.count = self.ROLL_TIMEOUT * 6
+                else:
+                    # Except when the backlight was off, then normal timeout.
+                    self.count = self.ROLL_TIMEOUT
+                    self.lcd.on = True
+                    self.screen_cycle.reset()
+                self.screen = self._roll_screens(False)
+            
+    def tick(self):
+        if self.count == 0:
+            self.screen = self._roll_screens(True)
+            if self.lcd.on_time > self.BACKLIGHT_TIMEOUT:
+                self.lcd.on = False
+        elif self.screen is not None:
+            # Update the screen text
+            self.screen.display(self.conn, self.lcd)
+        self.count = self.count - 1 if self.count > 0 else self.ROLL_TIMEOUT
+
+    def _show_screen(self, screen):
+        return screen.display(self.conn, self.lcd)
+
+    def _roll_screens(self, auto):
+        # Cheap way of avoiding infinite loop
+        for screen, _ in izip(self.screen_cycle, self._screens):
+            if auto and not screen.auto:
+                continue
+            if self._show_screen(screen):
+                return screen
+        return None
+
+


### PR DESCRIPTION
This merge request adds the following features: 
- Detects if a device has 4 button UI (only Venus PayGo for now)
- Starts the standard UI (0 or 1 button) or the 4 button UI accordingly
- 4 button UI allows navigation in between menus using up and down arrow to select menu, right arrow to enter menu and left arrow to exit menus. Alerts are displayed with priority if any. 
- Added a PayGo menu that can only work with 4 buttons to enter tokens

Internally the following changes have been made: 
- The existing one button UI has been split into a separate file called "simple_ui.py" with the same start(), key_pressed() and tick() functions as the "four_button_ui.py".
- In addition to the pages.py file that contains the classic menus, a "four_button_pages.py" file has been added for pages that only work with four buttons. 
- Finally, a payg_service.py file has been added to abstract the dbus communication with the paygo service. 