### PR TITLE
Adding new PAYGO Service Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Added an input to set the PAYGO LVD Threshold from the service menu
 
-- Added new battery menu displaying both Battery Current and Voltage
+- Added new Battery Status menu displaying both Battery Current and Voltage (the existing one was showing power instead)
 
 ## v1.1 - 2020-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## v1.2 - 2021-04-19
+## v1.2 - 2021-04-20
 
-- Added new battery menu displaying Battery Current and Voltage for systems with just an MPPT
+- Extracted the number entry logic into a separate reusable menu for 4 buttons devices
 
-- Added new 4 button menu allowing the entry of the LVD setting
+- Added a new password protected PAYGO Service Menu
+
+- Added an input to set the PAYGO LVD Threshold from the service menu
+
+- Added new battery menu displaying both Battery Current and Voltage
 
 ## v1.1 - 2020-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## v1.2 - 2021-04-19
+
+- Added new battery menu displaying Battery Current and Voltage for systems with just an MPPT
+
+- Added new 4 button menu allowing the entry of the LVD setting
+
+## v1.1 - 2020-11-16
+
+- Added support for 4 button UI
+
+- Added PAYGO Menus
+
+## v1.0 - ???
+
+- Initial Release

--- a/dbus_characterdisplay.py
+++ b/dbus_characterdisplay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python -u
 
 import sys
 import logging

--- a/dbus_characterdisplay.py
+++ b/dbus_characterdisplay.py
@@ -13,7 +13,7 @@ from evdev import InputDevice, ecodes
 import gobject
 import lcddriver
 from cache import smart_dict
-from pages import StatusPage, ReasonPage, BatteryPage, SolarPage, SolarHistoryPage, MPPTBatteryPage
+from pages import StatusPage, ReasonPage, BatteryPage, SolarPage, SolarHistoryPage, DetailedBatteryPage
 from pages import AcPage, AcPhasePage, AcOutPhasePage
 from pages import LanPage, WlanPage, VebusErrorPage, SolarErrorPage, VebusAlarmsPage
 from four_button_ui import FourButtonUserInterface
@@ -33,7 +33,7 @@ _screens = [StatusPage(), ReasonPage(), VebusErrorPage(),
 	AcPhasePage(3), AcOutPhasePage(3),
 	BatteryPage(), SolarPage(), SolarErrorPage(),
 	SolarHistoryPage(0), SolarHistoryPage(1),
-	LanPage(), WlanPage(), MPPTBatteryPage()]
+	LanPage(), WlanPage()]
 
 
 def main():
@@ -67,6 +67,13 @@ def main():
 	# Show spash screen while initialization
 	lcd.splash()
 
+	# Check the type of device
+	has_four_buttons = subprocess.check_output(["/usr/bin/board-compat"]).strip() in FOUR_BUTTON_DEVICES
+
+	# Add the screens only needed on the four button version
+	if has_four_buttons:
+		_screens.append(DetailedBatteryPage())
+
 	# Handle services that are already up
 	for name in conn.list_names():
 		if name.startswith("com.victronenergy."):
@@ -90,8 +97,6 @@ def main():
 		kbd = InputDevice("/dev/input/by-path/platform-disp_keys-event")
 	except OSError:
 		kbd = None
-
-	has_four_buttons = subprocess.check_output(["/usr/bin/board-compat"]).strip() in FOUR_BUTTON_DEVICES
 
 	if has_four_buttons:
 		ui_handler = FourButtonUserInterface(lcd, conn, kbd, _screens)

--- a/dbus_characterdisplay.py
+++ b/dbus_characterdisplay.py
@@ -13,7 +13,7 @@ from evdev import InputDevice, ecodes
 import gobject
 import lcddriver
 from cache import smart_dict
-from pages import StatusPage, ReasonPage, BatteryPage, SolarPage, SolarHistoryPage
+from pages import StatusPage, ReasonPage, BatteryPage, SolarPage, SolarHistoryPage, MPPTBatteryPage
 from pages import AcPage, AcPhasePage, AcOutPhasePage
 from pages import LanPage, WlanPage, VebusErrorPage, SolarErrorPage, VebusAlarmsPage
 from four_button_ui import FourButtonUserInterface
@@ -33,7 +33,7 @@ _screens = [StatusPage(), ReasonPage(), VebusErrorPage(),
 	AcPhasePage(3), AcOutPhasePage(3),
 	BatteryPage(), SolarPage(), SolarErrorPage(),
 	SolarHistoryPage(0), SolarHistoryPage(1),
-	LanPage(), WlanPage()]
+	LanPage(), WlanPage(), MPPTBatteryPage()]
 
 
 def main():

--- a/four_button_pages.py
+++ b/four_button_pages.py
@@ -55,10 +55,10 @@ class TokenEntryMenu(object):
             if key_pressed == ecodes.KEY_LEFT:
                 return False
         else:
-            if key_pressed or self.was_locked:
-                if self.was_locked:
-                    display.clear()
-                    self.was_locked = False
+            if self.was_locked:
+                display.clear()
+                self.was_locked = False
+                self.number_entry_menu.enter(conn, display)
             return self.number_entry_menu.update(conn, display, key_pressed)
         return True
 

--- a/four_button_pages.py
+++ b/four_button_pages.py
@@ -114,6 +114,7 @@ class NumberEntryMenu(object):
         self.prompt_text = prompt_text
         self.callback_function = callback_function
         self.starting_value_callback = starting_value_callback
+        self.ready = False
 
     def is_available(self, conn):
         return False
@@ -132,8 +133,11 @@ class NumberEntryMenu(object):
         display.clear()
         display.display_string(self.prompt_text, 1)
         display.display_string(self.to_display.ljust(self.number_length, '_'), 2)
+        self.ready = True
 
     def update(self, conn, display, key_pressed):
+        if not self.ready:
+            return True
         if self.entry_complete:
             if key_pressed:
                 return False
@@ -218,5 +222,7 @@ class ServiceMenu(object):
 
     def get_lvd_string(self):
         lvd_value = self.payg_service.get_lvd_value()
+        if not lvd_value:
+            lvd_value = 11.5
         lvd_value_string = str(int(float(lvd_value)*1000))
         return lvd_value_string

--- a/four_button_ui.py
+++ b/four_button_ui.py
@@ -25,7 +25,7 @@ class FourButtonUserInterface(object):
             ('WiFi Status', StaticMenu(self.static_pages[17])),
             ('General Status', StaticMenu(self.static_pages[0])),
             ('Solar Status', StaticMenu(self.static_pages[12])),
-            ('Battery Status', StaticMenu(self.static_pages[11])),
+            ('Battery Status', StaticMenu(self.static_pages[18])),
             ('Solar History', StaticMenu(self.static_pages[14])),
         ]
         self.alarm_menus = [

--- a/four_button_ui.py
+++ b/four_button_ui.py
@@ -1,6 +1,6 @@
 from evdev import ecodes
 from datetime import datetime, timedelta
-from four_button_pages import StaticMenu, TokenEntryMenu, PAYGStatusMenu
+from four_button_pages import StaticMenu, TokenEntryMenu, PAYGStatusMenu, ServiceMenu
 
 
 class FourButtonUserInterface(object):
@@ -27,6 +27,7 @@ class FourButtonUserInterface(object):
             ('Solar Status', StaticMenu(self.static_pages[12])),
             ('Battery Status', StaticMenu(self.static_pages[18])),
             ('Solar History', StaticMenu(self.static_pages[14])),
+            ('Service Menu', ServiceMenu(self.conn)),
         ]
         self.alarm_menus = [
             StaticMenu(self.static_pages[2]), # VE Bus error

--- a/pages.py
+++ b/pages.py
@@ -305,6 +305,29 @@ class BatteryPage(Page):
 			text[1][1] = "{:.1f} V".format(self.cache.battery_voltage)
 		return text
 
+class MPPTBatteryPage(Page):
+	def __init__(self):
+		super(MPPTBatteryPage, self).__init__()
+
+	def setup(self, conn, name):
+		if name.startswith("com.victronenergy.solarcharger."):
+			self.track(conn, name, "/Connected", "mppt_connected")
+			self.track(conn, name, "/Dc/0/Voltage", "battery_voltage")
+			self.track(conn, name, "/Dc/0/Current", "battery_current")
+
+	def get_text(self, conn):
+		# Skip page if no mppt connected
+		if not self.cache.mppt_connected:
+			return None
+
+		text = [[_("Battery") + ":", ""], ["", ""]]
+		if self.cache.battery_voltage is not None:
+			text[1][0] = "{:.1f} V".format(self.cache.battery_voltage)
+		if (self.cache.battery_current is not None):
+			text[1][1] = "{:.1f} A".format(self.cache.battery_current)
+		return text
+
+
 class SolarPage(Page):
 	def __init__(self):
 		super(SolarPage, self).__init__()

--- a/pages.py
+++ b/pages.py
@@ -308,6 +308,7 @@ class BatteryPage(Page):
 class MPPTBatteryPage(Page):
 	def __init__(self):
 		super(MPPTBatteryPage, self).__init__()
+		self.cache.mppt_connected = None
 
 	def setup(self, conn, name):
 		if name.startswith("com.victronenergy.solarcharger."):

--- a/pages.py
+++ b/pages.py
@@ -305,9 +305,9 @@ class BatteryPage(Page):
 			text[1][1] = "{:.1f} V".format(self.cache.battery_voltage)
 		return text
 
-class MPPTBatteryPage(Page):
+class DetailedBatteryPage(Page):
 	def __init__(self):
-		super(MPPTBatteryPage, self).__init__()
+		super(DetailedBatteryPage, self).__init__()
 		self.cache.mppt_connected = None
 
 	def setup(self, conn, name):

--- a/payg_service.py
+++ b/payg_service.py
@@ -65,6 +65,16 @@ class PAYGService(object):
         else:
             return False
 
+    def update_lvd_value(self, new_lvd_volts):
+        self._dbus_write(self.SERVICE_NAME, "/LVD/Threshold", new_lvd_volts)
+        return True
+
+    def get_lvd_value(self):
+        lvd_value = self.tracker.query(self.conn, self.SERVICE_NAME, "/LVD/Threshold")
+        if lvd_value is not None:
+            return lvd_value
+        return None
+
     def _get_expiration_date(self):
         expiration_date = self.tracker.query(self.conn, self.SERVICE_NAME, "/Status/ActiveUntilDate")
         if expiration_date is not None:


### PR DESCRIPTION
v1.2 - 2021-04-20

- Extracted the number entry logic into a separate reusable menu for 4 buttons devices

- Added a new password protected PAYGO Service Menu

- Added an input to set the PAYGO LVD Threshold from the service menu

- Added new Battery Status menu displaying both Battery Current and Voltage and is available even if SoC is not available (the existing one was showing power instead and requires a device that reports SoC)